### PR TITLE
Use module-wide logger instead of root logger.

### DIFF
--- a/pdfminer/cmapdb.py
+++ b/pdfminer/cmapdb.py
@@ -28,6 +28,9 @@ from .encodingdb import name2unicode
 from .utils import choplist, nunpack
 
 
+logger = logging.getLogger(__name__)
+
+
 class CMapError(Exception): pass
 
 
@@ -52,7 +55,7 @@ class CMap:
         copy(self.code2cid, cmap.code2cid)
 
     def decode(self, code):
-        logging.debug('decode: %r, %r', self, code)
+        logger.debug('decode: %r, %r', self, code)
         if isinstance(code, str):
             code = code.encode('latin-1')
         d = self.code2cid
@@ -90,7 +93,7 @@ class IdentityCMap:
             code = code.encode('latin-1')
         if len(code) % 2 != 0:
             # Something's wrong, but we have to at least prevent a crash by removing the last char
-            logging.warning("The code %r has an uneven length, trimming last byte.", code)
+            logger.warning("The code %r has an uneven length, trimming last byte.", code)
             code = code[:-1]
         n = len(code)//2
         if n:
@@ -106,7 +109,7 @@ class UnicodeMap:
         self.cid2unichr = cid2unichr or {}
 
     def get_unichr(self, cid):
-        logging.debug('get_unichr: %r, %r', self, cid)
+        logger.debug('get_unichr: %r, %r', self, cid)
         return self.cid2unichr[cid]
 
     def dump(self, out=sys.stdout):
@@ -211,7 +214,7 @@ class CMapDB:
     @classmethod
     def _load_data(klass, name):
         filename = '%s.pickle.gz' % name
-        logging.debug('loading: %s', name)
+        logger.debug('loading: %s', name)
         default_path = os.environ.get('CMAP_PATH', '/usr/share/pdfminer/')
         for directory in (os.path.dirname(cmap.__file__), default_path):
             path = os.path.join(directory, filename)

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -12,6 +12,9 @@ from .utils import apply_matrix_pt, mult_matrix
 from .utils import htmlescape, bbox2str, create_bmp
 
 
+logger = logging.getLogger(__name__)
+
+
 class PDFLayoutAnalyzer(PDFTextDevice):
 
     def __init__(self, rsrcmgr, pageno=1, laparams=None):
@@ -97,7 +100,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         return item.adv
 
     def handle_undefined_char(self, font, cid):
-        logging.warning('undefined: %r, %r', font, cid)
+        logger.warning('undefined: %r, %r', font, cid)
         return '(cid:%d)' % cid
 
     def receive_layout(self, ltpage):

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -4,6 +4,10 @@ from itertools import combinations
 from .utils import (INF, get_bound, uniq, fsplit, drange, bbox2str, matrix2str, apply_matrix_pt,
     trailiter)
 
+
+logger = logging.getLogger(__name__)
+
+
 class IndexAssigner:
 
     def __init__(self, index=0):
@@ -620,7 +624,7 @@ class LTLayoutContainer(LTContainer):
         if len(boxes) > 100:
             # Grouping this many boxes would take too long and it doesn't make much sense to do so
             # considering the type of grouping (nesting 2-sized subgroups) that is done here.
-            logging.warning("Too many boxes (%d) to group, skipping.", len(boxes))
+            logger.warning("Too many boxes (%d) to group, skipping.", len(boxes))
             return boxes
         # XXX this still takes O(n^2)  :(
         dists = []

--- a/pdfminer/lzw.py
+++ b/pdfminer/lzw.py
@@ -1,6 +1,10 @@
 import io
 import logging
 
+
+logger = logging.getLogger(__name__)
+
+
 class CorruptDataError(Exception):
     pass
 
@@ -85,7 +89,7 @@ class LZWDecoder:
                 # just ignore corrupt data and stop yielding there
                 break
             yield x
-            logging.debug('nbits=%d, code=%d, output=%r, table=%r', self.nbits, code, x, self.table)
+            logger.debug('nbits=%d, code=%d, output=%r, table=%r', self.nbits, code, x, self.table)
 
 # lzwdecode
 def lzwdecode(data):

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -16,6 +16,9 @@ from .utils import choplist
 from .utils import mult_matrix, MATRIX_IDENTITY
 
 
+logger = logging.getLogger(__name__)
+
+
 ##  Exceptions
 ##
 class PDFResourceError(PDFException): pass
@@ -133,7 +136,7 @@ class PDFResourceManager:
         if objid and objid in self._cached_fonts:
             font = self._cached_fonts[objid]
         else:
-            # logging.debug('get_font: create: objid=%r, spec=%r', objid, spec)
+            # logger.debug('get_font: create: objid=%r, spec=%r', objid, spec)
             if spec['Type'] is not LITERAL_FONT:
                 handle_error(PDFFontError, 'Type is not /Font')
             # Create a Font object.
@@ -266,7 +269,7 @@ class PDFPageInterpreter:
             else:
                 return PREDEFINED_COLORSPACE[name]
         for (k,v) in dict_value(resources).items():
-            # logging.debug('Resource: %r: %r', k,v)
+            # logger.debug('Resource: %r: %r', k,v)
             if k == 'Font':
                 for (fontid,spec) in dict_value(v).items():
                     objid = None
@@ -593,7 +596,7 @@ class PDFPageInterpreter:
         except TypeError:
             # Sometimes, 'obj' is a PSLiteral. I'm not sure why, but I'm guessing it's because it's
             # malformed or something. We can just ignore the thing.
-            logging.warning("Malformed inline image")
+            logger.warning("Malformed inline image")
 
     # invoke an XObject
     def do_Do(self, xobjid):
@@ -603,7 +606,7 @@ class PDFPageInterpreter:
         except KeyError:
             handle_error(PDFInterpreterError, 'Undefined xobject id: %r' % xobjid)
             return
-        logging.debug('Processing xobj: %r', xobj)
+        logger.debug('Processing xobj: %r', xobj)
         subtype = xobj.get('Subtype')
         if subtype is LITERAL_FORM and 'BBox' in xobj:
             interpreter = self.dup()
@@ -625,7 +628,7 @@ class PDFPageInterpreter:
             pass
 
     def process_page(self, page):
-        logging.debug('Processing page: %r', page)
+        logger.debug('Processing page: %r', page)
         (x0,y0,x1,y1) = page.mediabox
         if page.rotate == 90:
             ctm = (0,-1,1,0, -y0,x1)
@@ -643,7 +646,7 @@ class PDFPageInterpreter:
     #   Render the content streams.
     #   This method may be called recursively.
     def render_contents(self, resources, streams, ctm=MATRIX_IDENTITY):
-        logging.debug('render_contents: resources=%r, streams=%r, ctm=%r', resources, streams, ctm)
+        logger.debug('render_contents: resources=%r, streams=%r, ctm=%r', resources, streams, ctm)
         self.init_resources(resources)
         self.init_state(ctm)
         self.execute(list_value(streams))
@@ -667,11 +670,11 @@ class PDFPageInterpreter:
                     nargs = func.__code__.co_argcount-1
                     if nargs:
                         args = self.pop(nargs)
-                        # logging.debug('exec: %s %r', name, args)
+                        # logger.debug('exec: %s %r', name, args)
                         if len(args) == nargs:
                             func(*args)
                     else:
-                        # logging.debug('exec: %s', name)
+                        # logger.debug('exec: %s', name)
                         func()
                 else:
                     handle_error(PDFInterpreterError, 'Unknown operator: %r' % name)


### PR DESCRIPTION
Using root logger can generate verbose log messages for application wide. Also, it makes things hard when you need to change the log level for a particular module. This PR fixes this issue by using module-wide child logger instead of root logger.
